### PR TITLE
Added Option to Retrieve Tickets in Descending Order by ID

### DIFF
--- a/PSConnectWise/Private/PSCWApiClasses.ps1
+++ b/PSConnectWise/Private/PSCWApiClasses.ps1
@@ -662,10 +662,16 @@ class CwApiServiceTicketSvc : CWApiRestClientSvc
     
     [psobject[]] ReadTickets ([string] $ticketConditions, [string[]] $fields, [uint32] $pageNum, [uint32] $pageSize)
     {
+        return $this.ReadTickets($ticketConditions, $fields, $null, 1, 0);
+    }
+    
+    [psobject[]] ReadTickets ([string] $ticketConditions, [string[]] $fields, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
+    {
         [hashtable] $queryParams = @{
             conditions = $ticketConditions;
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
         
         if ($fields -ne $null)
@@ -735,7 +741,7 @@ class CwApiServiceBoardSvc : CWApiRestClientSvc
         $this.CWApiClient.RelativeBaseEndpointUri = "/service/boards";
     }
     
-    [psobject] ReadBoard ([int] $boardId)
+    [psobject] ReadBoard ([uint32] $boardId)
     {
         $relativePathUri = "/$boardId";
         return $this.ReadRequest($relativePathUri, $null);
@@ -838,7 +844,7 @@ class CwApiServiceBoardTypeSvc : CWApiRestClientSvc
         $this.CWApiClient.RelativeBaseEndpointUri = "/service/boards";
     }
     
-    [psobject] ReadType([int] $boardId, $typeId)
+    [psobject] ReadType([uint32] $boardId, $typeId)
     {
         $relativePathUri = "/$boardId/types/$typeId";
         return $this.ReadRequest($relativePathUri);
@@ -999,7 +1005,7 @@ class CwApiServiceTicketNoteSvc : CWApiRestClientSvc
         $this.CWApiClient.RelativeBaseEndpointUri = "/service/tickets";
     }
     
-    [psobject] ReadNote ([uint32] $ticketId, [int] $timeEntryId)
+    [psobject] ReadNote ([uint32] $ticketId, [uint32] $timeEntryId)
     {
         $relativePathUri = "/$ticketId/notes/$timeEntryId";
         return $this.ReadRequest($relativePathUri, $null);

--- a/PSConnectWise/Public/CWCompany.ps1
+++ b/PSConnectWise/Public/CWCompany.ps1
@@ -30,6 +30,7 @@ function Get-CWCompany
     [OutputType("PSObject", ParameterSetName="Normal")]
     [OutputType("PSObject", ParameterSetName="Identifier")]
     [OutputType("PSObject[]", ParameterSetName="Query")]
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
@@ -47,7 +48,8 @@ function Get-CWCompany
         [ValidateNotNullOrEmpty()]
         [string[]]$Property,
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
-        [uint32]$SizeLimit,
+        [ValidateRange(1, 2000)]
+        [uint32]$SizeLimit = 100,
         [Parameter(ParameterSetName='Normal', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Identifier', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=2, Mandatory=$true)]

--- a/PSConnectWise/Public/CWCompanyContact.ps1
+++ b/PSConnectWise/Public/CWCompanyContact.ps1
@@ -19,6 +19,7 @@ function Get-CWCompanyContact
     [CmdLetBinding()]
     [OutputType("PSObject[]", ParameterSetName="Normal")]
     [OutputType("PSObject", ParameterSetName="Single")]
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
@@ -27,6 +28,9 @@ function Get-CWCompanyContact
         [Parameter(ParameterSetName='Single', Position=0, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [uint32]$ID,
+        [Parameter(ParameterSetName='Normal', Mandatory=$false)]
+        [ValidateRange(1, 2000)]
+        [uint32]$SizeLimit = 100,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [Parameter(ParameterSetName='Single', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]

--- a/PSConnectWise/Public/CWServiceBoard.ps1
+++ b/PSConnectWise/Public/CWServiceBoard.ps1
@@ -21,6 +21,7 @@ function Get-CWServiceBoard
     [CmdLetBinding()]
     [OutputType("PSObject[]", ParameterSetName="Normal")]
     [OutputType("PSObject", ParameterSetName="Single")]
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
@@ -30,7 +31,8 @@ function Get-CWServiceBoard
         [ValidateNotNullOrEmpty()]
         [string]$Filter,
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
-        [uint32]$SizeLimit,
+        [ValidateRange(1, 2000)]
+        [uint32]$SizeLimit = 100,
         [Parameter(ParameterSetName='Normal', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=2, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]

--- a/PSConnectWise/Public/CWServiceBoard.ps1
+++ b/PSConnectWise/Public/CWServiceBoard.ps1
@@ -30,7 +30,7 @@ function Get-CWServiceBoard
         [ValidateNotNullOrEmpty()]
         [string]$Filter,
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
-        [int]$SizeLimit,
+        [uint32]$SizeLimit,
         [Parameter(ParameterSetName='Normal', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=2, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]

--- a/PSConnectWise/Public/CWServiceBoardStatus.ps1
+++ b/PSConnectWise/Public/CWServiceBoardStatus.ps1
@@ -12,7 +12,8 @@
 function Get-CWServiceBoardStatus
 {
     [CmdLetBinding()]
-    [OutputType("PSObject[]", ParameterSetName="Normal")]
+    [OutputType("PSObject[]", ParameterSetName="Normal")]    
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]

--- a/PSConnectWise/Public/CWServiceBoardSubtype.ps1
+++ b/PSConnectWise/Public/CWServiceBoardSubtype.ps1
@@ -13,6 +13,7 @@ function Get-CWServiceBoardSubtype
 {
     [CmdLetBinding()]
     [OutputType("PSObject[]", ParameterSetName="Normal")]
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]

--- a/PSConnectWise/Public/CWServiceBoardType.ps1
+++ b/PSConnectWise/Public/CWServiceBoardType.ps1
@@ -13,6 +13,7 @@ function Get-CWServiceBoardType
 {
     [CmdLetBinding()]
     [OutputType("PSObject[]", ParameterSetName="Normal")]
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]

--- a/PSConnectWise/Public/CWServicePriority.ps1
+++ b/PSConnectWise/Public/CWServicePriority.ps1
@@ -21,6 +21,7 @@ function Get-CWServicePriority
     [CmdLetBinding()]
     [OutputType("PSObject[]", ParameterSetName="Normal")]
     [OutputType("PSObject[]", ParameterSetName="Query")]
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
@@ -30,7 +31,8 @@ function Get-CWServicePriority
         [ValidateNotNullOrEmpty()]
         [string]$Filter,
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
-        [uint32]$SizeLimit,
+        [ValidateRange(1, 2000)]
+        [uint32]$SizeLimit = 100,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]

--- a/PSConnectWise/Public/CWServicePriority.ps1
+++ b/PSConnectWise/Public/CWServicePriority.ps1
@@ -30,7 +30,7 @@ function Get-CWServicePriority
         [ValidateNotNullOrEmpty()]
         [string]$Filter,
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
-        [int]$SizeLimit,
+        [uint32]$SizeLimit,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]

--- a/PSConnectWise/Public/CWServiceTicketNote.ps1
+++ b/PSConnectWise/Public/CWServiceTicketNote.ps1
@@ -19,6 +19,7 @@ function Get-CWServiceTicketNote
     [CmdLetBinding()]
     [OutputType("PSObject", ParameterSetName="Normal")]
     [OutputType("PSObject", ParameterSetName="Single")]
+    [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true)]


### PR DESCRIPTION
In addition to the `-Descending` switch being added to `Get-CWServiceTicket`:  all functions now have default parameter sets; `-SizeLimit` parameter defaults to CW's documented default of 100, `-SizeLimit` range is between 1 and 2k (also CW's documented max).