### PR TITLE
closes #16; add wildcard search and -descending

### DIFF
--- a/PSConnectWise/Private/PSCWApiClasses.ps1
+++ b/PSConnectWise/Private/PSCWApiClasses.ps1
@@ -657,12 +657,12 @@ class CwApiServiceTicketSvc : CWApiRestClientSvc
     
     [psobject[]] ReadTickets ([string] $ticketConditions, [string[]] $fields, [uint32] $pageNum)
     {        
-        return $this.ReadTickets($ticketConditions, $fields, 1, 0);
+        return $this.ReadTickets($ticketConditions, $fields, $pageNum, 0);
     }
     
     [psobject[]] ReadTickets ([string] $ticketConditions, [string[]] $fields, [uint32] $pageNum, [uint32] $pageSize)
     {
-        return $this.ReadTickets($ticketConditions, $fields, $null, 1, 0);
+        return $this.ReadTickets($ticketConditions, $fields, $null, $pageNum, $pageSize);
     }
     
     [psobject[]] ReadTickets ([string] $ticketConditions, [string[]] $fields, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
@@ -754,15 +754,21 @@ class CwApiServiceBoardSvc : CWApiRestClientSvc
     
     [psobject[]] ReadBoards ([string] $boardConditions, [uint32] $pageNum)
     {         
-        return $this.ReadBoards($boardConditions, 1, 0);
+        return $this.ReadBoards($boardConditions, $pageNum, 0);
     }
     
     [psobject[]] ReadBoards ([string] $boardConditions, [uint32] $pageNum, [uint32] $pageSize)
+    {         
+        return $this.ReadBoards($boardConditions, $null, $pageNum, $pageSize);
+    }
+    
+    [psobject[]] ReadBoards ([string] $boardConditions, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
     {
         [hashtable] $queryHashtable = @{
             conditions = $boardConditions;
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
         
         return $this.ReadRequest($null, $queryHashtable);
@@ -805,15 +811,21 @@ class CwApiServiceBoardStatusSvc : CWApiRestClientSvc
     
     [psobject[]] ReadStatuses ([uint32] $boardId, [string] $fields, [uint32] $pageNum)
     {         
-        return $this.ReadStatuses($boardId, $fields, 1, 0);
+        return $this.ReadStatuses($boardId, $fields, $pageNum, 0);
     }
     
     [psobject[]] ReadStatuses ([uint32] $boardId, [string] $fields, [uint32] $pageNum, [uint32] $pageSize)
+    {         
+        return $this.ReadStatuses($boardId, $fields, $null, $pageNum, $pageSize);
+    }
+    
+    [psobject[]] ReadStatuses ([uint32] $boardId, [string] $fields, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
     {
         [hashtable] $queryHashtable = @{
             fields     = $fields;
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
 
         $relativePathUri = "/$boardId/statuses";
@@ -862,15 +874,21 @@ class CwApiServiceBoardTypeSvc : CWApiRestClientSvc
     
     [psobject[]] ReadTypes ([uint32] $boardId, [string] $fields, [uint32] $pageNum)
     {         
-        return $this.ReadTypes($boardId, $fields, 1, 0);
+        return $this.ReadTypes($boardId, $fields, $pageNum, 0);
     }
     
     [psobject[]] ReadTypes ([uint32] $boardId, [string] $fields, [uint32] $pageNum, [uint32] $pageSize)
+    {         
+        return $this.ReadTypes($boardId, $fields, $null, $pageNum, $pageSize);
+    }
+    
+    [psobject[]] ReadTypes ([uint32] $boardId, [string] $fields, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
     {
         [hashtable] $queryHashtable = @{
             fields     = $fields;
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
 
         $relativePathUri = "/$boardId/types";
@@ -919,15 +937,21 @@ class CwApiServiceBoardSubtypeSvc : CWApiRestClientSvc
     
     [psobject[]] ReadTypes ([uint32] $boardId, [string] $fields, [uint32] $pageNum)
     {         
-        return $this.ReadTypes($boardId, $fields, 1, 0);
+        return $this.ReadTypes($boardId, $fields, $pageNum, 0);
     }
     
     [psobject[]] ReadTypes ([uint32] $boardId, [string] $fields, [uint32] $pageNum, [uint32] $pageSize)
+    {         
+        return $this.ReadTypes($boardId, $fields, $null, $pageNum, $pageSize);
+    }
+    
+    [psobject[]] ReadTypes ([uint32] $boardId, [string] $fields, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
     {
         [hashtable] $queryHashtable = @{
             fields     = $fields;
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
         
         $relativePathUri = "/$boardId/subtypes";
@@ -972,15 +996,21 @@ class CwApiServicePrioritySvc : CWApiRestClientSvc
     
     [psobject[]] ReadPriorities ([string] $priorityConditions, [uint32] $pageNum)
     {         
-        return $this.ReadPriorities($priorityConditions, 1, 0);
+        return $this.ReadPriorities($priorityConditions, $pageNum, 0);
+    }
+
+    [psobject[]] ReadPriorities ([string] $priorityConditions, [uint32] $pageNum, [uint32] $pageSize)
+    {         
+        return $this.ReadPriorities($priorityConditions, $null, $pageNum, $pageSize);
     }
     
-    [psobject[]] ReadPriorities ([string] $priorityConditions, [uint32] $pageNum, [uint32] $pageSize)
+    [psobject[]] ReadPriorities ([string] $priorityConditions, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
     {
         [hashtable] $queryHashtable = @{
             conditions = $priorityConditions;
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
         
         return $this.ReadRequest($null, $queryHashtable);
@@ -1013,14 +1043,20 @@ class CwApiServiceTicketNoteSvc : CWApiRestClientSvc
     
     [psobject[]] ReadNotes ([uint32] $ticketId)
     {
-        return $this.ReadTimeEntries($ticketId, 1, 0)
+        return $this.ReadNotes($ticketId, 1, 0)
     }
     
     [psobject[]] ReadNotes ([uint32] $ticketId, [uint32] $pageNum, [uint32] $pageSize)
     {
+        return $this.ReadNotes($ticketId, $null, $pageNum, $pageSize)
+    }
+    
+    [psobject[]] ReadNotes ([uint32] $ticketId, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
+    {
         [hashtable] $queryHashtable = @{
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
         
         $relativePathUri = "/$ticketId/notes";
@@ -1082,18 +1118,6 @@ class CwApiCompanySvc : CWApiRestClientSvc
         return $company
     }
     
-    [psobject] ReadCompany([string] $companIdenifier)
-    {
-        return $this.ReadCompany($companIdenifier, "*");
-    }
-
-    [psobject] ReadCompany([string] $companIdenifier, $fields)
-    {
-        $query = "identifier='$companIdenifier'";
-        [pscustomobject[]] $company = $this.ReadCompanies($query, $fields);
-        return $company[0];
-    }
-    
     [psobject[]] ReadCompanies ([string] $companyConditions)
     {        
         return $this.ReadCompanies($companyConditions, "*");
@@ -1111,10 +1135,16 @@ class CwApiCompanySvc : CWApiRestClientSvc
     
     [psobject[]] ReadCompanies ([string] $companyConditions, [string[]] $fields, [uint32] $pageNum, [uint32] $pageSize)
     {
+        return $this.ReadCompanies($companyConditions, $fields, $null, $pageNum, 0);
+    }
+    
+    [psobject[]] ReadCompanies ([string] $companyConditions, [string[]] $fields, [string]$orderBy, [uint32] $pageNum, [uint32] $pageSize)
+    {
         [hashtable] $queryHashtable = @{
             conditions = $companyConditions;
             page       = $pageNum;
             pageSize   = $pageSize;
+            orderBy    = $orderBy;
         }
         
         if ($fields -ne $null)
@@ -1178,13 +1208,18 @@ class CwApiCompanyContactSvc : CWApiRestClientSvc
     
     [psobject[]] ReadCompanyContacts ([uint32] $companyId, [string[]] $fields, [uint32] $pageNum)
     {
-        return $this.ReadCompanyContacts($companyId, $fields, 1, 0);
+        return $this.ReadCompanyContacts($companyId, $fields, $pageNum, 0);
     }
     
     [psobject[]] ReadCompanyContacts ([uint32] $companyId, [string[]] $fields, [uint32] $pageNum, [uint32] $pageSize)
     {
+        return $this.ReadCompanyContacts($companyId, $fields, $null, $pageNum, $pageSize);
+    }
+    
+    [psobject[]] ReadCompanyContacts ([uint32] $companyId, [string[]] $fields, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
+    {
         $query = "company/id=$companyId";
-        return $this.ReadContacts($query, $fields, $pageNum, $pageSize);
+        return $this.ReadContacts($query, $fields, $orderBy, $pageNum, $pageSize);
     }
     
     [psobject[]] ReadContacts ([string] $companyConditions)
@@ -1199,16 +1234,22 @@ class CwApiCompanyContactSvc : CWApiRestClientSvc
     
     [psobject[]] ReadContacts ([string] $companyConditions, [string[]] $fields, [uint32] $pageNum)
     {         
-        return $this.ReadContacts($companyConditions, $fields, 1, 0);
+        return $this.ReadContacts($companyConditions, $fields, $fields, 0);
     }
     
     [psobject[]] ReadContacts ([string] $companyConditions, [string[]] $fields,  [uint32] $pageNum, [uint32] $pageSize)
+    {         
+        return $this.ReadContacts($companyConditions, $fields, $null, $fields, $pageSize);
+    }
+    
+    [psobject[]] ReadContacts ([string] $companyConditions, [string[]] $fields, [string] $orderBy, [uint32] $pageNum, [uint32] $pageSize)
     {
         [hashtable] $queryHashtable = @{
             conditions = $companyConditions;
             page       = $pageNum;
             pageSize   = $pageSize;
             fields     = $null;
+            orderBy    = $orderBy;
         }
         
         if ($fields -ne $null)

--- a/PSConnectWise/Public/CWCompany.ps1
+++ b/PSConnectWise/Public/CWCompany.ps1
@@ -13,6 +13,8 @@
     Name of the properties to return
 .PARAMETER SizeLimit
     Max number of items to return
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -59,6 +61,10 @@ function Get-CWCompany
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
         [ValidateRange(1, 1000)]
         [uint32]$SizeLimit = 100,
+        [Parameter(ParameterSetName='Identifier')]
+        [Parameter(ParameterSetName='Name')]
+        [Parameter(ParameterSetName='Query')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Identifier', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Name', Position=2, Mandatory=$true)]
@@ -70,7 +76,8 @@ function Get-CWCompany
     Begin
     {
         $MAX_ITEMS_PER_PAGE = 50;
-        [CwApiCompanySvc] $CompanySvr = $null; 
+        [CwApiCompanySvc] $CompanySvr = $null;
+        [string]$OrderBy = [String]::Empty;
         
         # get the Company service
         if ($Server -ne $null)
@@ -118,6 +125,12 @@ function Get-CWCompany
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Companies Per Pages): $pageCount";
         } # end if for filter/identifier check
         
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
+        }
+        
         # determines if to select all fields or specific fields
         [string[]] $Properties = $null;
         if ($Property -ne $null)
@@ -145,7 +158,7 @@ function Get-CWCompany
                 }
                 
                 Write-Debug "Requesting Company IDs that Meets this Filter: $Filter";
-                $queriedCompanies = $CompanySvc.ReadCompanies($Filter, $Properties, $pageNum, $itemsPerPage);
+                $queriedCompanies = $CompanySvc.ReadCompanies($Filter, $Properties, $OrderBy, $pageNum, $itemsPerPage);
                 [psobject[]] $Companies = $queriedCompanies;
                 
                 foreach ($Company in $Companies)

--- a/PSConnectWise/Public/CWCompany.ps1
+++ b/PSConnectWise/Public/CWCompany.ps1
@@ -107,7 +107,6 @@ function Get-CWCompany
                 if ($Name -contains "*")
                 {
                     $Filter = "name like '$Name'";
-
                 }
                 Write-Verbose "Created a Filter String Based on the Identifier Value ($Identifier): $Filter";
             }

--- a/PSConnectWise/Public/CWCompany.ps1
+++ b/PSConnectWise/Public/CWCompany.ps1
@@ -5,6 +5,8 @@
     ConnectWise company ID
 .PARAMETER Identifier
     ConnectWise company identifier name
+.PARAMETER Name
+    ConnectWise company friendly name
 .PARAMETER Filter
     Query String 
 .PARAMETER Property
@@ -29,6 +31,7 @@ function Get-CWCompany
     [CmdLetBinding()]
     [OutputType("PSObject", ParameterSetName="Normal")]
     [OutputType("PSObject[]", ParameterSetName="Identifier")]
+    [OutputType("PSObject[]", ParameterSetName="Name")]
     [OutputType("PSObject[]", ParameterSetName="Query")]
     [CmdletBinding(DefaultParameterSetName="Normal")]
     param
@@ -39,20 +42,26 @@ function Get-CWCompany
         [Parameter(ParameterSetName='Identifier', Position=0, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Identifier,
+        [Parameter(ParameterSetName='Name', Position=0, Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string[]]$Name,
         [Parameter(ParameterSetName='Query', Position=0, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string]$Filter,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$false)]
         [Parameter(ParameterSetName='Identifier', Position=1, Mandatory=$false)]
+        [Parameter(ParameterSetName='Name', Position=1, Mandatory=$false)]
         [Parameter(ParameterSetName='Query', Position=1, Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Property,
         [Parameter(ParameterSetName='Identifier', Position=1, Mandatory=$false)]
+        [Parameter(ParameterSetName='Name', Position=1, Mandatory=$false)]
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
         [ValidateRange(1, 1000)]
         [uint32]$SizeLimit = 100,
         [Parameter(ParameterSetName='Normal', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Identifier', Position=2, Mandatory=$true)]
+        [Parameter(ParameterSetName='Name', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=2, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$Server
@@ -67,18 +76,13 @@ function Get-CWCompany
         if ($Server -ne $null)
         {
             $CompanySvc = [CwApiCompanySvc]::new($Server);
-        } 
-        else 
-        {
-            # TODO: determine whether or not to keep this as an option
-            $CompanySvc = [CwApiCompanySvc]::new($Domain, $CompanyName, $PublicKey, $PrivateKey);
         }
         
         [uint32] $companyCount = $MAX_ITEMS_PER_PAGE;
         [uint32] $pageCount  = 1;
         
         # get the number of pages of ticket to request and total ticket count
-        if (![String]::IsNullOrWhiteSpace($Filter) -or ![String]::IsNullOrWhiteSpace($Identifier))
+        if (![String]::IsNullOrWhiteSpace($Filter) -or ![String]::IsNullOrWhiteSpace($Identifier) -or ![String]::IsNullOrWhiteSpace($Name))
         {
             if (![String]::IsNullOrWhiteSpace($Identifier))
             {
@@ -86,6 +90,16 @@ function Get-CWCompany
                 if ($Identifier -contains "*")
                 {
                     $Filter = "identifier like '$Identifier'";
+
+                }
+                Write-Verbose "Created a Filter String Based on the Identifier Value ($Identifier): $Filter";
+            }
+            elseif (![String]::IsNullOrWhiteSpace($Name))
+            {
+                $Filter = "name='$Name'";
+                if ($Name -contains "*")
+                {
+                    $Filter = "name like '$Name'";
 
                 }
                 Write-Verbose "Created a Filter String Based on the Identifier Value ($Identifier): $Filter";

--- a/PSConnectWise/Public/CWCompany.ps1
+++ b/PSConnectWise/Public/CWCompany.ps1
@@ -94,7 +94,7 @@ function Get-CWCompany
             if (![String]::IsNullOrWhiteSpace($Identifier))
             {
                 $Filter = "identifier='$Identifier'";
-                if ($Identifier -contains "*")
+                if ([RegEx]::IsMatch($Identifier, "\*"))
                 {
                     $Filter = "identifier like '$Identifier'";
 

--- a/PSConnectWise/Public/CWCompanyContact.ps1
+++ b/PSConnectWise/Public/CWCompanyContact.ps1
@@ -76,7 +76,7 @@ function Get-CWCompanyContact
             {
                 $Filter = "company/id=$CompanyID";
                 
-                if ($FirstName -contains "*")
+                if ([RegEx]::IsMatch($FirstName, "\*"))
                 {
                     $Filter += " and firstname like '$FirstName'"
                 }
@@ -85,7 +85,7 @@ function Get-CWCompanyContact
                     $Filter += " and firstname='$FirstName'"
                 }
                     
-                if ($LastName -contains "*")
+                if ([RegEx]::IsMatch($LastName, "\*"))
                 {
                     $Filter += " and lastname like '$LastName'"
                 }

--- a/PSConnectWise/Public/CWCompanyContact.ps1
+++ b/PSConnectWise/Public/CWCompanyContact.ps1
@@ -5,6 +5,8 @@
     ConnectWise contact ID
 .PARAMETER CompanyID
     ConnectWise company ID
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -31,6 +33,8 @@ function Get-CWCompanyContact
         [Parameter(ParameterSetName='Normal', Mandatory=$false)]
         [ValidateRange(1, 1000)]
         [uint32]$SizeLimit = 100,
+        [Parameter(ParameterSetName='Normal')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [Parameter(ParameterSetName='Single', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
@@ -40,8 +44,8 @@ function Get-CWCompanyContact
     Begin
     {
         $MAX_ITEMS_PER_PAGE = 50;
-        
         [CwApiCompanyContactSvc] $ContactSvc = $null; 
+        [string]$OrderBy = [String]::Empty;
         
         # get the Company service
         if ($Server -ne $null)
@@ -72,6 +76,13 @@ function Get-CWCompanyContact
             
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Company Contacts Per Pages): $pageCount";
         }
+        
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
+        }
+        
     }
     Process
     {

--- a/PSConnectWise/Public/CWCompanyContact.ps1
+++ b/PSConnectWise/Public/CWCompanyContact.ps1
@@ -100,7 +100,7 @@ function Get-CWCompanyContact
                 }
                 
                 Write-Debug "Requesting Contact Entries for Company: $CompanyID";
-                $queriedContacts = $ContactSvc.ReadCompanyContacts($CompanyID, $null, $pageNum, $itemsPerPage);
+                $queriedContacts = $ContactSvc.ReadCompanyContacts($CompanyID, $OrderBy, $pageNum, $itemsPerPage);
                 [pscustomobject[]] $Contacts = $queriedContacts;
             
             } else {

--- a/PSConnectWise/Public/CWServiceBoard.ps1
+++ b/PSConnectWise/Public/CWServiceBoard.ps1
@@ -132,7 +132,7 @@ function Get-CWServiceBoard
                 }
                 
                 Write-Debug "Requesting Board IDs that Meets this Filter: $Filter";
-                $queriedBoards = $BoardSvc.ReadBoards($Filter, $pageNum, $itemsPerPage);
+                $queriedBoards = $BoardSvc.ReadBoards($Filter, $OrderBy, $pageNum, $itemsPerPage);
                 [pscustomobject[]] $Boards = $queriedBoards;
                 
                 foreach ($Board in $Boards)

--- a/PSConnectWise/Public/CWServiceBoard.ps1
+++ b/PSConnectWise/Public/CWServiceBoard.ps1
@@ -78,7 +78,7 @@ function Get-CWServiceBoard
             if (![String]::IsNullOrWhiteSpace($Name))
             {
                 $Filter = "name='$Name'";
-                if ($Name -contains "*")
+                if ([RegEx]::IsMatch($Name, "\*"))
                 {
                     $Filter = "name like '$Name'";
 

--- a/PSConnectWise/Public/CWServiceBoard.ps1
+++ b/PSConnectWise/Public/CWServiceBoard.ps1
@@ -9,6 +9,8 @@
     Query String 
 .PARAMETER SizeLimit
     Max number of items to return
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -40,6 +42,9 @@ function Get-CWServiceBoard
         [Parameter(ParameterSetName='Query')]
         [ValidateRange(1, 1000)]
         [uint32]$SizeLimit = 100,
+        [Parameter(ParameterSetName='Name')]
+        [Parameter(ParameterSetName='Query')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Name', Position=2, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=2, Mandatory=$true)]
@@ -51,6 +56,7 @@ function Get-CWServiceBoard
     {
         $MAX_ITEMS_PER_PAGE = 50;
         [CwApiServiceBoardSvc] $BoardSvc = $null; 
+        [string]$OrderBy = [String]::Empty;
         
         # get the Company service
         if ($Server -ne $null)
@@ -91,6 +97,12 @@ function Get-CWServiceBoard
             $pageCount = [Math]::Ceiling([double]($boardCount / $MAX_ITEMS_PER_PAGE));
             
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Boards Per Pages): $pageCount";
+        }
+        
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
         }
         
         # determines if to select all fields or specific fields

--- a/PSConnectWise/Public/CWServiceBoardStatus.ps1
+++ b/PSConnectWise/Public/CWServiceBoardStatus.ps1
@@ -3,6 +3,8 @@
     Gets ConnectWise board's status information. 
 .PARAMETER BoardID
     ConnectWise board ID
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -19,6 +21,8 @@ function Get-CWServiceBoardStatus
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
         [ValidateNotNullOrEmpty()]
         [uint32]$BoardID,
+        [Parameter(ParameterSetName='Normal')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=2, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$Server
@@ -28,6 +32,7 @@ function Get-CWServiceBoardStatus
     {
         $MAX_ITEMS_PER_PAGE = 50;
         [CwApiServiceBoardStatusSvc] $BoardStatusSvc = $null; 
+        [string]$OrderBy = [String]::Empty;
         
         # get the Company service
         if ($Server -ne $null)
@@ -56,6 +61,12 @@ function Get-CWServiceBoardStatus
             $pageCount = [Math]::Ceiling([double]($statusCount / $MAX_ITEMS_PER_PAGE));
             
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Boards Per Pages): $pageCount";
+        }
+        
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
         }
     }
     Process

--- a/PSConnectWise/Public/CWServiceBoardStatus.ps1
+++ b/PSConnectWise/Public/CWServiceBoardStatus.ps1
@@ -84,7 +84,7 @@ function Get-CWServiceBoardStatus
                 }
                 
                 Write-Debug "Requesting Ticket IDs that Meets this Filter: $Filter";
-                $queriedStatuses = $BoardStatusSvc.ReadStatuses($boardId, [string[]] @("*"), $pageNum, $itemsPerPage);
+                $queriedStatuses = $BoardStatusSvc.ReadStatuses($boardId, [string[]] @("*"), $OrderBy, $pageNum, $itemsPerPage);
                 [pscustomobject[]] $Statuses = $queriedStatuses;
                 
                 foreach ($Status in $Statuses)

--- a/PSConnectWise/Public/CWServiceBoardSubtype.ps1
+++ b/PSConnectWise/Public/CWServiceBoardSubtype.ps1
@@ -3,6 +3,8 @@
     Gets ConnectWise board's type and subtype information. 
 .PARAMETER BoardID
     ConnectWise board ID
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -19,6 +21,8 @@ function Get-CWServiceBoardSubtype
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
         [ValidateNotNullOrEmpty()]
         [uint32]$BoardID,
+        [Parameter(ParameterSetName='Normal')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$Server
@@ -28,6 +32,7 @@ function Get-CWServiceBoardSubtype
     {
         $MAX_ITEMS_PER_PAGE = 50;
         [CwApiServiceBoardSubtypeSvc] $BoardTypeSvc = $null; 
+        [string]$OrderBy = [String]::Empty;
         
         # get the Company service
         if ($Server -ne $null)
@@ -56,6 +61,12 @@ function Get-CWServiceBoardSubtype
             $pageCount = [Math]::Ceiling([double]($typeCount / $MAX_ITEMS_PER_PAGE));
             
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Types Per Pages): $pageCount";
+        }
+        
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
         }
     }
     Process

--- a/PSConnectWise/Public/CWServiceBoardSubtype.ps1
+++ b/PSConnectWise/Public/CWServiceBoardSubtype.ps1
@@ -84,7 +84,7 @@ function Get-CWServiceBoardSubtype
                 }                
                 
                 Write-Debug "Requesting Type IDs for BoardID: $BoardID";
-                $queriedTypes = $BoardTypeSvc.ReadTypes($boardId, [string[]] @("*"), $pageNum, $itemsPerPage);
+                $queriedTypes = $BoardTypeSvc.ReadTypes($boardId, [string[]] @("*"), $OrderBy, $pageNum, $itemsPerPage);
                 [pscustomobject[]] $Types = $queriedTypes;
                 
                 foreach ($Type in $Types)

--- a/PSConnectWise/Public/CWServiceBoardType.ps1
+++ b/PSConnectWise/Public/CWServiceBoardType.ps1
@@ -84,7 +84,7 @@ function Get-CWServiceBoardType
                 }                
                 
                 Write-Debug "Requesting Type IDs for BoardID: $BoardID";
-                $queriedTypes = $BoardTypeSvc.ReadTypes($boardId, [string[]] @("*"), $pageNum, $itemsPerPage);
+                $queriedTypes = $BoardTypeSvc.ReadTypes($boardId, [string[]] @("*"), $OrderBy, $pageNum, $itemsPerPage);
                 [pscustomobject[]] $Types = $queriedTypes;
                 
                 foreach ($Type in $Types)

--- a/PSConnectWise/Public/CWServiceBoardType.ps1
+++ b/PSConnectWise/Public/CWServiceBoardType.ps1
@@ -3,6 +3,8 @@
     Gets ConnectWise board's type and subtype information. 
 .PARAMETER BoardID
     ConnectWise board ID
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -19,6 +21,8 @@ function Get-CWServiceBoardType
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
         [ValidateNotNullOrEmpty()]
         [uint32]$BoardID,
+        [Parameter(ParameterSetName='Normal')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [PSObject]$Server
@@ -28,6 +32,7 @@ function Get-CWServiceBoardType
     {
         $MAX_ITEMS_PER_PAGE = 50;
         [CwApiServiceBoardTypeSvc] $BoardTypeSvc = $null; 
+        [string]$OrderBy = [String]::Empty;
         
         # get the Company service
         if ($Server -ne $null)
@@ -56,6 +61,12 @@ function Get-CWServiceBoardType
             $pageCount = [Math]::Ceiling([double]($typeCount / $MAX_ITEMS_PER_PAGE));
             
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Types Per Pages): $pageCount";
+        }
+        
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
         }
     }
     Process

--- a/PSConnectWise/Public/CWServicePriority.ps1
+++ b/PSConnectWise/Public/CWServicePriority.ps1
@@ -102,7 +102,7 @@ function Get-CWServicePriority
                 }    
                 
                 Write-Debug "Requesting Priority IDs that Meets this Filter: $Filter";
-                $queriedPriorities = $PrioritySvc.ReadPriorities($Filter, $pageNum, $itemsPerPage);
+                $queriedPriorities = $PrioritySvc.ReadPriorities($Filter, $OrderBy, $pageNum, $itemsPerPage);
                 [pscustomobject[]] $Priorities = $queriedPriorities;
                 
                 foreach ($Priority in $Priorities)

--- a/PSConnectWise/Public/CWServicePriority.ps1
+++ b/PSConnectWise/Public/CWServicePriority.ps1
@@ -7,6 +7,8 @@
     Query String 
 .PARAMETER SizeLimit
     Max number of items to return
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -19,7 +21,7 @@
 function Get-CWServicePriority
 {
     [CmdLetBinding()]
-    [OutputType("PSObject[]", ParameterSetName="Normal")]
+    [OutputType("PSObject", ParameterSetName="Normal")]
     [OutputType("PSObject[]", ParameterSetName="Query")]
     [CmdletBinding(DefaultParameterSetName="Normal")]
     param
@@ -33,6 +35,8 @@ function Get-CWServicePriority
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
         [ValidateRange(1, 1000)]
         [uint32]$SizeLimit = 100,
+        [Parameter(ParameterSetName='Query')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
@@ -43,6 +47,7 @@ function Get-CWServicePriority
     {
         $MAX_ITEMS_PER_PAGE = 50;
         [CwApiServicePrioritySvc] $PrioritySvc = $null; 
+        [string]$OrderBy = [String]::Empty;
         
         # get the Company service
         if ($Server -ne $null)
@@ -72,6 +77,12 @@ function Get-CWServicePriority
             $pageCount = [Math]::Ceiling([double]($priorityCount / $MAX_ITEMS_PER_PAGE));
             
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Priorities Per Pages): $pageCount";
+        }
+        
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
         }
         
     }

--- a/PSConnectWise/Public/CWServiceTicket.ps1
+++ b/PSConnectWise/Public/CWServiceTicket.ps1
@@ -25,25 +25,33 @@ function Get-CWServiceTicket
     [CmdLetBinding()]
     [OutputType("PSObject", ParameterSetName="Normal")]
     [OutputType("PSObject[]", ParameterSetName="Query")]
+    [OutputType("PSObject[]", ParameterSetName="Summary")]
     [CmdletBinding(DefaultParameterSetName="Normal")]
     param
     (
         [Parameter(ParameterSetName='Normal', Position=0, Mandatory=$true, ValueFromPipeline=$true)]
         [ValidateNotNullOrEmpty()]
         [int[]]$ID,
+        [Parameter(ParameterSetName='Summary', Position=0, Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Summary,
         [Parameter(ParameterSetName='Query', Position=0, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [string]$Filter,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$false)]
+        [Parameter(ParameterSetName='Summary', Mandatory=$false)]
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
         [ValidateNotNullOrEmpty()]
         [string[]]$Property,
+        [Parameter(ParameterSetName='Summary', Mandatory=$false)]
         [Parameter(ParameterSetName='Query', Mandatory=$false)]
         [ValidateRange(1, 1000)]
         [int]$SizeLimit = 100,
+        [Parameter(ParameterSetName='Summary')]
         [Parameter(ParameterSetName='Query')]
         [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Mandatory=$true)]
+        [Parameter(ParameterSetName='Summary', Mandatory=$true)]
         [Parameter(ParameterSetName='Query', Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [PSCustomObject]$Server
@@ -69,8 +77,18 @@ function Get-CWServiceTicket
         [uint32] $pageCount   = 1;
         
         # get the number of pages of ticket to request and total ticket count
-        if (![String]::IsNullOrWhiteSpace($Filter))
+        if (![String]::IsNullOrWhiteSpace($Filter) -or ![String]::IsNullOrWhiteSpace($Summary))
         {
+            if (![String]::IsNullOrWhiteSpace($Summary))
+            {
+                $Filter = "summary='$Summary'";
+                if ([RegEx]::IsMatch($Summary, "\*"))
+                {
+                    $Filter = "summary like '$Summary'";
+                }
+                Write-Verbose "Created a Filter String Based on the Summary Value ($Summary): $Filter";
+            }
+            
             $ticketCount = $TicketSvc.GetTicketCount($Filter);
             Write-Debug "Total Count Ticket the Filter ($Filter): $ticketCount";
             

--- a/PSConnectWise/Public/CWServiceTicketNote.ps1
+++ b/PSConnectWise/Public/CWServiceTicketNote.ps1
@@ -5,6 +5,8 @@
     ConnectWise ticket ID
 .PARAMETER NoteID
     ConnectWise ticket note ID
+.PARAMETER Descending
+    Changes the sorting to descending order by IDs
 .PARAMETER Server
     Variable to the object created via Get-CWConnectWiseInfo
 .EXAMPLE
@@ -17,7 +19,7 @@
 function Get-CWServiceTicketNote
 {
     [CmdLetBinding()]
-    [OutputType("PSObject", ParameterSetName="Normal")]
+    [OutputType("PSObject[]", ParameterSetName="Normal")]
     [OutputType("PSObject", ParameterSetName="Single")]
     [CmdletBinding(DefaultParameterSetName="Normal")]
     param
@@ -29,6 +31,8 @@ function Get-CWServiceTicketNote
         [Parameter(ParameterSetName='Single', Position=1, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
         [int32]$NoteID,
+        [Parameter(ParameterSetName='Normal')]
+        [switch]$Descending,
         [Parameter(ParameterSetName='Normal', Position=1, Mandatory=$true)]
         [Parameter(ParameterSetName='Single', Position=2, Mandatory=$true)]
         [ValidateNotNullOrEmpty()]
@@ -39,6 +43,7 @@ function Get-CWServiceTicketNote
     {
         $MAX_ITEMS_PER_PAGE = 50;
         [CwApiServiceTicketNoteSvc] $NoteSvc = $null; 
+        [string]$OrderBy = [String]::Empty;
         
         # get the Note service
         if ($Server -ne $null)
@@ -67,6 +72,12 @@ function Get-CWServiceTicketNote
             $pageCount = [Math]::Ceiling([double]($noteCount / $MAX_ITEMS_PER_PAGE));
             
             Write-Debug "Total Number of Pages ($MAX_ITEMS_PER_PAGE Ticket Notes Per Pages): $pageCount";
+        }
+        
+        #specify the ordering
+        if ($Descending)
+        {
+            $OrderBy = " id desc";
         }
     }
     Process

--- a/PSConnectWise/Public/CWServiceTicketNote.ps1
+++ b/PSConnectWise/Public/CWServiceTicketNote.ps1
@@ -96,7 +96,7 @@ function Get-CWServiceTicketNote
                 }  
                 
                 Write-Debug "Requesting Note Entries for Ticket: $TicketID";
-                $queriedNotes = $NoteSvc.ReadNotes($TicketID, $pageNum, $itemsPerPage);
+                $queriedNotes = $NoteSvc.ReadNotes($TicketID, $OrderBy, $pageNum, $itemsPerPage);
                 [pscustomobject[]] $Notes = $queriedNotes;
             
             } else {

--- a/test/CWCompany.Tests.ps1
+++ b/test/CWCompany.Tests.ps1
@@ -15,6 +15,7 @@ Describe 'CWCompany' {
         $pstrCompanyIDs        = $pstrComp.companyIds;
 		$pstrCompanyID         = $pstrComp.companyIds[0];
 		$pstrCompanyIdentifier = $pstrComp.companyIdentifier;
+		$pstrCompanyName       = $pstrComp.companyName;
 	
         It 'gets company and checks for the id field' {
 			$companyID = $pstrCompanyID;
@@ -76,6 +77,17 @@ Describe 'CWCompany' {
 		It 'get single company by Identifier parameter' {
 			$companies = Get-CWCompany -Identifier $pstrCompanyIdentifier -Server $pstrServer;
 			$companies.identifier | Should Be $pstrCompanyIdentifier;
+		}
+		
+		It 'wildcard search using Name parameter with SizeLimit parameter' {
+			$sizeLimit = 5;
+			$companies = Get-CWCompany -Name "*" -SizeLimit $sizeLimit -Server $pstrServer;
+			$companies | Measure-Object | Select -ExpandProperty Count | Should Be $sizeLimit ;
+		}
+		
+		It 'get single company by Name parameter' {
+			$companies = Get-CWCompany -Name $pstrCompanyName -Server $pstrServer;
+			$companies -ne $null | Should Be $true;
 		}
         
     }

--- a/test/CWCompany.Tests.ps1
+++ b/test/CWCompany.Tests.ps1
@@ -5,7 +5,8 @@ Import-Module "$WorkspaceRoot\PSConnectWise\PSConnectWise.psm1" -Force
 
 Describe 'CWCompany' {
 		
-	. "$WorkspaceRoot\test\LoadTestSettings.ps1"
+	. "$WorkspaceRoot\test\LoadTestSettings.ps1";
+	[hashtable] $pstrSharedValues = @{};
 	
 	# get the server connnection
 	$pstrServer = Get-CWConnectionInfo -Domain $pstrSvrDomain -CompanyName $pstrSvrCompany -PublicKey $pstrSvrPublic -PrivateKey $pstrSvrPrivate;
@@ -20,7 +21,8 @@ Describe 'CWCompany' {
         It 'gets company and checks for the id field' {
 			$companyID = $pstrCompanyID;
 			$company = Get-CWCompany -ID $companyID -Server $pstrServer
-			$company.id | Should Be $companyID;		
+			$pstrSharedValues.Add("company", $company);
+			$pstrSharedValues['company'].id | Should Be $companyID;		
 		} 
 		
 		It 'gets company and pipes it through the Select-Object cmdlet for the id property' {
@@ -75,8 +77,9 @@ Describe 'CWCompany' {
 		}
 		
 		It 'get single company by Identifier parameter' {
-			$companies = Get-CWCompany -Identifier $pstrCompanyIdentifier -Server $pstrServer;
-			$companies.identifier | Should Be $pstrCompanyIdentifier;
+			$companyIdentifier = $pstrSharedValues['company'].identifier
+			$companies = Get-CWCompany -Identifier $companyIdentifier -Server $pstrServer;
+			$companies.identifier | Should Be $companyIdentifier;
 		}
 		
 		It 'wildcard search using Name parameter with SizeLimit parameter' {
@@ -86,8 +89,15 @@ Describe 'CWCompany' {
 		}
 		
 		It 'get single company by Name parameter' {
-			$companies = Get-CWCompany -Name $pstrCompanyName -Server $pstrServer;
-			$companies -ne $null | Should Be $true;
+			$companyName = $pstrSharedValues['company'].name
+			$companies = Get-CWCompany -Name $companyName -Server $pstrServer;
+			$companyName -ne $null | Should Be $true;
+		}
+		
+		It 'wildcard search using Name parameter with Descending parameter' {
+			$sizeLimit = 5;
+			$companies = Get-CWCompany -Name "*" -SizeLimit $sizeLimit -Descending -Server $pstrServer;
+			$companies[0].id -gt $companies[$companies.Count - 1].id | Should Be $true ;
 		}
         
     }

--- a/test/CWServiceBoard.Tests.ps1
+++ b/test/CWServiceBoard.Tests.ps1
@@ -6,7 +6,8 @@ Import-Module "$WorkspaceRoot\PSConnectWise\PSConnectWise.psm1" -Force
 Describe 'CWServiceBoard' {
 		
 	. "$WorkspaceRoot\test\LoadTestSettings.ps1"
-	
+	[hashtable] $pstrSharedValues = @{};
+
 	# get the server connnection
 	$pstrServer = Get-CWConnectionInfo -Domain $pstrSvrDomain -CompanyName $pstrSvrCompany -PublicKey $pstrSvrPublic -PrivateKey $pstrSvrPrivate;
 	
@@ -19,7 +20,8 @@ Describe 'CWServiceBoard' {
 		It 'gets board and checks for the id field' {
 			$boardID = $pstrBoardID;
 			$board = Get-CWServiceBoard -ID $boardID -Server $pstrServer;
-			$board.id | Should Be $boardID;		
+			$pstrSharedValues.Add("board", $board);
+			$pstrSharedValues['board'].id | Should Be $boardID;		
 		}
 		
 		It 'gets board and pipes it through the Select-Object cmdlet for the id property' {
@@ -67,8 +69,9 @@ Describe 'CWServiceBoard' {
 		}
 		
 		It 'get single board by Name parameter' {
-			$boards = Get-CWServiceBoard -Name $pstrBoardName -Server $pstrServer;
-			$boards.name | Should Be $pstrBoardName;
+			$boardName = $pstrSharedValues['board'].name
+			$boards = Get-CWServiceBoard -Name $boardName -Server $pstrServer;
+			$boards.name | Should Be $boardName;
 		}
 	
 	}

--- a/test/CWServiceTicket.Tests.ps1
+++ b/test/CWServiceTicket.Tests.ps1
@@ -19,7 +19,8 @@ Describe 'CWServiceTicket' {
 		It 'gets ticket and checks for the id field' {
 			$ticketID = $pstrTicketID;
 			$ticket = Get-CWServiceTicket -ID $ticketID -Server $pstrServer;
-			$ticket.id | Should Be $ticketID;		
+			$pstrSharedValues.Add("ticket", $ticket);
+			$pstrSharedValues['ticket'].id | Should Be $ticketID;		
 		} 
 		
 		It 'gets ticket and pipes it through the Select-Object cmdlet for the id property' {
@@ -66,6 +67,28 @@ Describe 'CWServiceTicket' {
 			$maxTicketId = $ticketIDs | Measure-Object -Maximum | Select -ExpandProperty Maximum
 			$tickets[0].id | Should Be $maxTicketId;		
 		}
+		
+		It 'wildcard search using Summary parameter with SizeLimit parameter' {
+			$sizeLimit = 5;
+			$ticketSummary = $pstrSharedValues['ticket'].summary
+			$tickets = Get-CWServiceTicket -Summary "$ticketSummary*" -SizeLimit $sizeLimit -Server $pstrServer;
+			$count = $tickets | Measure-Object | Select -ExpandProperty Count;
+			$count -gt 0 -and $count -le $sizeLimit | Should Be $true ;
+		}
+		
+		It 'get tickets by Summary parameter' {
+			$ticketSummary = $pstrSharedValues['ticket'].summary
+			$tickets = Get-CWServiceTicket -Summary $ticketSummary -Server $pstrServer;
+			$tickets -ne $null | Should Be $true;
+		}
+		
+		It 'wildcard search using Filter parameter with Descending parameter' {
+			$sizeLimit = 5;
+			$minTicketId = [Math]::Max(0, $pstrSharedValues['ticket'].id - 100);
+			$tickets = Get-CWServiceTicket -Filter "id > $minTicketId" -SizeLimit $sizeLimit -Descending -Server $pstrServer;
+			$tickets[0].id -ge $tickets[$tickets.Count - 1].id | Should Be $true ;
+		}
+		
 		
 	} # end of Context 'Get-CWServiceTicket'
 	

--- a/testSettings.example.json
+++ b/testSettings.example.json
@@ -15,7 +15,6 @@
         "service": {
             "ticketIds": [1000, 1001, 1002, 1003, 1004, 1005],
             "boardIds": [1, 2, 3, 4, 5],
-            "boardName": "Help",
             "statusIds": [105, 104, 103, 102, 101],
             "priorityIds": [8, 7, 6, 5, 4],
             "ticketNoteIds": [123456]
@@ -23,8 +22,6 @@
         
         // variables to be used when making calls to ConnectWise's Company module
         "company": {
-            "companyIdentifier": "acme",
-            "companyName": "Acme Inc",
             "companyIds": [1, 2],
             "contactIds": [1, 2, 3, 4, 5]
         }

--- a/testSettings.example.json
+++ b/testSettings.example.json
@@ -24,6 +24,7 @@
         // variables to be used when making calls to ConnectWise's Company module
         "company": {
             "companyIdentifier": "acme",
+            "companyName": "Acme Inc",
             "companyIds": [1, 2],
             "contactIds": [1, 2, 3, 4, 5]
         }


### PR DESCRIPTION
Added `-Descending` switch to all get functions. And added wildcard searching:

- `Get-CWServiceTicket` - Summary
- `Get-CWCompany` - Name
- `Get-CWCompany` - FirstName and LastName
- `Get-CWServiceBoard` - Name

The `wildcard search using Summary parameter with SizeLimit` under `CWServiceTicket` test fails due to a ConnectWise bug. I have reported the bug to CW Support via #7926276.